### PR TITLE
init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Editor directories and files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Dependencies
+node_modules/
+vendor/
+
+# Build outputs
+dist/
+build/
+out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/name-generator/.gitignore
+++ b/name-generator/.gitignore
@@ -1,0 +1,40 @@
+# Dependencies
+node_modules/
+vendor/
+package-lock.json
+yarn.lock
+
+# Build outputs
+dist/
+build/
+out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/vicious_mockery/.gitignore
+++ b/vicious_mockery/.gitignore
@@ -1,0 +1,28 @@
+# Perl specific
+/blib/
+/.build/
+_build/
+cover_db/
+inc/
+Build
+!Build/
+Build.bat
+.last_cover_stats
+/Makefile
+/Makefile.old
+/MANIFEST.bak
+/META.yml
+/META.json
+/MYMETA.*
+nytprof.out
+/pm_to_blib
+*.o
+*.bs
+/_eumm/
+*.pl~
+
+# Docker related
+.dockerignore
+
+# Local development
+local/

--- a/vicious_mockery/vicious_mockery.pl
+++ b/vicious_mockery/vicious_mockery.pl
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+my @openings = (
+    "Thy", "Ye foul", "Loathsome", "Accursed", "Pitiful", 
+    "Sniveling", "Hollow-skulled", "Odious", "Vile", "Wretched",
+    "Base-born", "Craven", "Grotesque", "Ignoble", "Stinking"
+);
+my @adjectives =(
+    "goat-breathed", "pustule-covered", "witless", "ill-begotten", 
+    "slime-slicked", "flea-bitten", "mud-crusted", "brainless", 
+    "craven", "fish-smelling", "snot-encrusted", "grub-ridden", 
+    "mildew-hearted", "bootlicking", "canker-blossomed", 
+    "weasel-faced", "sweat-drenched", "barnacle-headed"
+);
+my @nouns = (
+    "toadstool", "goblin-sniffer", "half-baked kobold", 
+    "gnoll's toenail", "orc-mothered swine", "rust monster reject",
+    "grease elemental", "quasit-flinger", "beholder’s lint", 
+    "dung beetle juggler", "gelatinous cube enthusiast", 
+    "undead mime", "kobold’s footstool", "soggy owl pellet", 
+    "failed familiars instructor", "dwarven beard louse", 
+    "tarrasque tickler", "lich’s toe fungus"
+);
+
+my $insult = join ' ',
+    $openings[ int(rand(@openings)) ],
+    $adjectives[ int(rand(@adjectives)) ],
+    $nouns[ int(rand(@nouns)) ];
+
+print "$insult!\n";


### PR DESCRIPTION
This pull request includes updates to `.gitignore` files for better dependency and build management, as well as the addition of a new Perl script for generating random insults.

### Updates to `.gitignore` files:

* [`name-generator/.gitignore`](diffhunk://#diff-c22e0c1ee04aabf8f28c8b65d824580b2c1d918a82a10232ca65b67475ac87a5R1-R40): Added rules to ignore dependencies, build outputs, environment variables, logs, editor directories, and OS-generated files.
* [`vicious_mockery/.gitignore`](diffhunk://#diff-5c104326f52c1fb57210fac6e6f150d484461f4b896d85705465dbe879d05e52R1-R28): Added rules to ignore Perl-specific files, Docker-related files, and local development files.

### Addition of new Perl script:

* [`vicious_mockery/vicious_mockery.pl`](diffhunk://#diff-3d1a894a285aca0ec40c4447867b4de9aeb3a90b2296ea21e32ed4a84b3f0b17R1-R32): Introduced a Perl script that generates random insults by combining elements from predefined lists of openings, adjectives, and nouns.